### PR TITLE
add sanitizeConfiguration method in ConstraintSolver

### DIFF
--- a/src/constraintsolver/ConstraintSolver.java
+++ b/src/constraintsolver/ConstraintSolver.java
@@ -1,5 +1,6 @@
 package constraintsolver;
 
+import org.checkerframework.dataflow.analysis.RegularTransferResult;
 import org.checkerframework.framework.type.QualifierHierarchy;
 import org.checkerframework.javacutil.ErrorReporter;
 
@@ -58,6 +59,7 @@ public class ConstraintSolver implements InferenceSolver {
             Collection<Constraint> constraints, QualifierHierarchy qualHierarchy,
             ProcessingEnvironment processingEnvironment) {
         configure(configuration);
+
         // record constraint size
         StatisticPrinter.record(StatisticKey.CONSTRAINT_SIZE, (long) constraints.size());
         // record slot size
@@ -83,6 +85,14 @@ public class ConstraintSolver implements InferenceSolver {
             PrintUtils.writeStatistic(StatisticPrinter.getStatistic());
         }
         return solution;
+    }
+
+    /**
+     * sanitize the configuration of solver
+     * sub-class may override this method to sanitize the configuration of solver
+     */
+    protected void sanitizeConfiguration() {
+
     }
 
     protected ConstraintGraph generateGraph(Collection<Slot> slots, Collection<Constraint> constraints) {
@@ -129,6 +139,8 @@ public class ConstraintSolver implements InferenceSolver {
             this.collectStatistic = true;
         }
 
+        // sanitize the configuration if needs
+        sanitizeConfiguration();
         System.out.println("configuration: \nback end type: " + this.backEndType + "; \nuseGraph: "
                 + this.useGraph + "; \nsolveInParallel: " + this.solveInParallel + ".");
     }

--- a/src/constraintsolver/ConstraintSolver.java
+++ b/src/constraintsolver/ConstraintSolver.java
@@ -1,6 +1,5 @@
 package constraintsolver;
 
-import org.checkerframework.dataflow.analysis.RegularTransferResult;
 import org.checkerframework.framework.type.QualifierHierarchy;
 import org.checkerframework.javacutil.ErrorReporter;
 
@@ -59,7 +58,6 @@ public class ConstraintSolver implements InferenceSolver {
             Collection<Constraint> constraints, QualifierHierarchy qualHierarchy,
             ProcessingEnvironment processingEnvironment) {
         configure(configuration);
-
         // record constraint size
         StatisticPrinter.record(StatisticKey.CONSTRAINT_SIZE, (long) constraints.size());
         // record slot size

--- a/src/constraintsolver/ConstraintSolver.java
+++ b/src/constraintsolver/ConstraintSolver.java
@@ -86,8 +86,9 @@ public class ConstraintSolver implements InferenceSolver {
     }
 
     /**
-     * sanitize the configuration of solver
-     * sub-class may override this method to sanitize the configuration of solver
+     * Sanitize and apply check of the configuration of solver based on a specific type system.
+     * Sub-class solver of a specific type system may override this method to sanitize the configuration of solver
+     * in the context of that type system.
      */
     protected void sanitizeConfiguration() {
 

--- a/src/dataflow/solvers/backend/DataflowConstraintSolver.java
+++ b/src/dataflow/solvers/backend/DataflowConstraintSolver.java
@@ -130,4 +130,12 @@ public class DataflowConstraintSolver extends ConstraintSolver {
         return new DefaultInferenceSolution(result);
     }
 
+    @Override
+    protected void sanitizeConfiguration() {
+        if (!useGraph) {
+            useGraph = true;
+            InferenceMain.getInstance().logger.warning("DataflowConstraintSolver: Don't use graph to solve constraints will "
+                    + "cause wrong answers in Dataflow type system. Modified solver argument \"useGraph\" to true.");
+        }
+    }
 }


### PR DESCRIPTION
add `sanitizeConfiguration` method in `ConstraintSolver`.

The purpose of this method is enable the sub-class of `ConstraintSolver` could do a customize check of user configuration.

This is useful if some type systems has a special requirement of some solver arguments value.

e.g. In `Ontology` system and `Dataflow` system, they should enforce the `useGraph` option to be `true` as we solving the Ontology constraints by applying a divide-and-conqure idea based on a constraint graph. For this situation, we can customized and enforce the configuration in `OntologyConstraintSolver` by overriding this `sanitizeConfiguration` method.

