### PR TITLE
clean up the usage of SlotManager#nextId()

### DIFF
--- a/src/dataflow/DataflowInferenceTreeAnnotator.java
+++ b/src/dataflow/DataflowInferenceTreeAnnotator.java
@@ -113,7 +113,7 @@ public class DataflowInferenceTreeAnnotator extends InferenceTreeAnnotator {
     }
 
     private void replaceATM(AnnotatedTypeMirror atm, AnnotationMirror dataflowAM) {
-        final ConstantSlot cs = new ConstantSlot(dataflowAM, slotManager.nextId());
+        final ConstantSlot cs = slotManager.createConstantSlot(dataflowAM);
         slotManager.createConstantSlot(dataflowAM);
         AnnotationBuilder ab = new AnnotationBuilder(realTypeFactory.getProcessingEnv(), VarAnnot.class);
         ab.setValue("value", cs.getId());

--- a/src/dataflow/solvers/classic/DatatypeSolver.java
+++ b/src/dataflow/solvers/classic/DatatypeSolver.java
@@ -63,7 +63,7 @@ public class DatatypeSolver {
         Map<Integer, Boolean> idToExistence = new HashMap<>();
         Map<Integer, Boolean> result = new HashMap<>();
 
-        final int totalVars = slotManager.nextId();
+        final int totalVars = slotManager.getNumberOfSlots();
         final int totalClauses = clauses.size();
 
         try {

--- a/src/generalconstraintsolver/dataflowsolver/dataflowsatsolver/DatatypeLingelingSatSolver.java
+++ b/src/generalconstraintsolver/dataflowsolver/dataflowsatsolver/DatatypeLingelingSatSolver.java
@@ -48,7 +48,7 @@ public class DatatypeLingelingSatSolver extends SatSubSolver {
         String datatype = DataflowUtils.getTypeNames(logic.getLattice().top)[0];
         sb.append("c This is the input for ");
         sb.append(datatype + "\n");
-        final int totalVars = (slotManager.nextId() * lattice.numModifiers);
+        final int totalVars = (slotManager.getNumberOfSlots() * lattice.numModifiers);
         final int totalClauses = clauses.size();
         sb.append("p cnf ");
         sb.append(totalVars + " ");

--- a/src/generalconstraintsolver/dataflowsolver/dataflowsatsolver/DatatypeSatSolver.java
+++ b/src/generalconstraintsolver/dataflowsolver/dataflowsatsolver/DatatypeSatSolver.java
@@ -22,8 +22,8 @@ public class DatatypeSatSolver extends SatSubSolver {
     public int[] dataflowsatSolve() {
         List<VecInt> clauses = convertImpliesToClauses();
         becomeWellForm(clauses);
-        final int totalVars = (slotManager.nextId() * lattice.numModifiers);
-        final int totalClauses = clauses.size() + slotManager.nextId()
+        final int totalVars = (slotManager.getNumberOfSlots() * lattice.numModifiers);
+        final int totalClauses = clauses.size() + slotManager.getNumberOfSlots()
                 * (1 + (lattice.numModifiers * (lattice.numModifiers - 1) / 2));
         final WeightedMaxSatDecorator solver = new WeightedMaxSatDecorator(
                 org.sat4j.pb.SolverFactory.newBoth());

--- a/src/generalconstraintsolver/satsubsolver/SatSubSolver.java
+++ b/src/generalconstraintsolver/satsubsolver/SatSubSolver.java
@@ -111,9 +111,9 @@ public class SatSubSolver {
         Map<Integer, AnnotationMirror> result = new HashMap<>();
         List<VecInt> clauses = convertImpliesToClauses();
         becomeWellForm(clauses);
-        final int totalVars = (slotManager.nextId() * lattice.numModifiers);
+        final int totalVars = (slotManager.getNumberOfSlots() * lattice.numModifiers);
         final int totalClauses = clauses.size()
-                + slotManager.nextId() * (1 + (lattice.numModifiers * (lattice.numModifiers - 1) / 2));
+                + slotManager.getNumberOfSlots() * (1 + (lattice.numModifiers * (lattice.numModifiers - 1) / 2));
         final WeightedMaxSatDecorator solver = new WeightedMaxSatDecorator(
                 org.sat4j.pb.SolverFactory.newBoth());
 

--- a/src/maxsatbackend/LingelingBackEnd.java
+++ b/src/maxsatbackend/LingelingBackEnd.java
@@ -50,7 +50,7 @@ public class LingelingBackEnd extends MaxSatBackEnd {
 
     private void buildCNF(List<VecInt> clauses) {
         CNFInput.append("c This is the CNF input\n");
-        final int totalVars = (slotManager.nextId() * lattice.numTypes);
+        final int totalVars = (slotManager.getNumberOfSlots() * lattice.numTypes);
         // TODO: We need to handle softclauses at some point...
         final int totalClauses = hardClauses.size();
         CNFInput.append("p cnf ");

--- a/src/maxsatbackend/MaxSatBackEnd.java
+++ b/src/maxsatbackend/MaxSatBackEnd.java
@@ -177,7 +177,7 @@ public class MaxSatBackEnd extends BackEnd<VecInt[], VecInt[]> {
      * @param solver
      */
     private void configureSatSolver(WeightedMaxSatDecorator solver) {
-        final int totalVars = (slotManager.nextId() * lattice.numTypes);
+        final int totalVars = (slotManager.getNumberOfSlots() * lattice.numTypes);
         final int totalClauses = hardClauses.size() + softClauses.size();
 
         solver.newVar(totalVars);

--- a/src/util/PrintUtils.java
+++ b/src/util/PrintUtils.java
@@ -19,7 +19,7 @@ public class PrintUtils {
      */
     public static void printResult(Map<Integer, AnnotationMirror> result) {
 
-        final int maxLength = String.valueOf(InferenceMain.getInstance().getSlotManager().nextId()).length();
+        final int maxLength = String.valueOf(InferenceMain.getInstance().getSlotManager().getNumberOfSlots()).length();
         StringBuilder printResult = new StringBuilder();
         System.out.println("/***********************results****************************/");
         for (Integer j : result.keySet()) {
@@ -68,7 +68,7 @@ public class PrintUtils {
 
     public static void writeResult(Map<Integer, AnnotationMirror> result) {
         StringBuilder printResult = new StringBuilder();
-        final int maxLength = String.valueOf(InferenceMain.getInstance().getSlotManager().nextId())
+        final int maxLength = String.valueOf(InferenceMain.getInstance().getSlotManager().getNumberOfSlots())
                 .length();
 
         for (Integer j : result.keySet()) {


### PR DESCRIPTION
Clean up the usage of `SlotManger#nextId()` based on the discussion here:

https://github.com/pascaliUWat/checker-framework-inference/pull/3

For the purpose of getting total number of slots, one should use `SlotManager#getNumberOfSlots()`.

@Jianchu I'm not quite sure whether my modification is correct for below locations:

- src/generalconstraintsolver/dataflowsolver/dataflowsatsolver/DatatypeSatSolver.java
- src/generalconstraintsolver/satsubsolver/SatSubSolver.java

as these locations continuously use `SlotManager#nextId()` twice, which means the value of `totalClauses` would be different from previous after changing the computation based on `nextId()` to `getNumberOfSlots()`.

Please have a look on this and any feedback would be appreciated!