### PR TITLE
update scripts

### DIFF
--- a/integrationSetup.sh
+++ b/integrationSetup.sh
@@ -26,5 +26,6 @@ ln -s $MYDIR/testing/dataflow $MYDIR/../checker-framework-inference/testdata
 
 ln -s $MYDIR/testing/dataflowexample $MYDIR/..
 
-bash $MYDIR/scripts/compile.sh
+gradle -b $MYDIR/build.gradle clean build
+
 gradle -b $MYDIR/../checker-framework-inference/build.gradle dist

--- a/scripts/dataflow/inference-MAXSAT-parallel.sh
+++ b/scripts/dataflow/inference-MAXSAT-parallel.sh
@@ -4,4 +4,7 @@ export MYDIR=`dirname $0`/..
 . $MYDIR/setup.sh
 export ROOT=$MYDIR/../..
 distDir=$CHINF"/dist"
-java -classpath "$distDir"/checker.jar:"$distDir"/plume.jar:"$distDir"/checker-framework-inference.jar:$ROOT/generic-type-inference-solver/bin:. checkers.inference.InferenceLauncher --solverArgs="backEndType=maxsatbackend.MaxSat" --checker dataflow.DataflowChecker --solver dataflow.solvers.backend.DataflowConstraintSolver --mode INFER --hacks=true $*
+
+export CLASSPATH=$ROOT/generic-type-inference-solver/bin:.
+
+$ROOT/checker-framework-inference/scripts/inference-dev checkers.inference.InferenceLauncher --solverArgs="backEndType=maxsatbackend.MaxSat" --checker dataflow.DataflowChecker --solver dataflow.solvers.backend.DataflowConstraintSolver --mode INFER --hacks=true $*

--- a/scripts/dataflow/inference-MAXSAT-sequence.sh
+++ b/scripts/dataflow/inference-MAXSAT-sequence.sh
@@ -4,4 +4,7 @@ export MYDIR=`dirname $0`/..
 . $MYDIR/setup.sh
 export ROOT=$MYDIR/../..
 distDir=$CHINF"/dist"
-java -classpath "$distDir"/checker.jar:"$distDir"/plume.jar:"$distDir"/checker-framework-inference.jar:$ROOT/generic-type-inference-solver/bin:. checkers.inference.InferenceLauncher --solverArgs="solveInParallel=false" --checker dataflow.DataflowChecker --solver dataflow.solvers.backend.DataflowConstraintSolver --mode INFER --hacks=true $*
+
+export CLASSPATH=$ROOT/generic-type-inference-solver/bin:.
+
+$ROOT/checker-framework-inference/scripts/inference-dev checkers.inference.InferenceLauncher --solverArgs="solveInParallel=false" --checker dataflow.DataflowChecker --solver dataflow.solvers.backend.DataflowConstraintSolver --mode INFER --hacks=true $*

--- a/scripts/dataflow/inference-classic.sh
+++ b/scripts/dataflow/inference-classic.sh
@@ -4,4 +4,7 @@ export MYDIR=`dirname $0`/..
 . $MYDIR/setup.sh
 export ROOT=$MYDIR/../..
 distDir=$CHINF"/dist"
-java -classpath "$distDir"/checker.jar:"$distDir"/plume.jar:"$distDir"/checker-framework-inference.jar:$ROOT/generic-type-inference-solver/bin:. checkers.inference.InferenceLauncher --checker dataflow.DataflowChecker --solver dataflow.solvers.classic.DataflowSolver --mode INFER --hacks=true $*
+
+export CLASSPATH=$ROOT/generic-type-inference-solver/bin:.
+
+$ROOT/checker-framework-inference/scripts/inference-dev checkers.inference.InferenceLauncher --checker dataflow.DataflowChecker --solver dataflow.solvers.classic.DataflowSolver --mode INFER --hacks=true $*

--- a/scripts/dataflow/inference-debug.sh
+++ b/scripts/dataflow/inference-debug.sh
@@ -4,4 +4,7 @@ export MYDIR=`dirname $0`/..
 . $MYDIR/setup.sh
 export ROOT=$MYDIR/../..
 distDir=$CHINF"/dist"
-java -classpath "$distDir"/checker.jar:"$distDir"/plume.jar:"$distDir"/checker-framework-inference.jar:$ROOT/generic-type-inference-solver/bin:.  checkers.inference.InferenceLauncher --checker dataflow.DataflowChecker --solver checkers.inference.solver.DebugSolver --mode INFER --hacks=true $*
+
+export CLASSPATH=$ROOT/generic-type-inference-solver/bin:.
+
+$ROOT/checker-framework-inference/scripts/inference-dev checkers.inference.InferenceLauncher --checker dataflow.DataflowChecker --solver checkers.inference.solver.DebugSolver --mode INFER --hacks=true $*

--- a/scripts/dataflow/inference-lingeling.sh
+++ b/scripts/dataflow/inference-lingeling.sh
@@ -4,4 +4,7 @@ export MYDIR=`dirname $0`/..
 . $MYDIR/setup.sh
 export ROOT=$MYDIR/../..
 distDir=$CHINF"/dist"
-java -classpath "$distDir"/checker.jar:"$distDir"/plume.jar:"$distDir"/checker-framework-inference.jar:$ROOT/generic-type-inference-solver/bin:. checkers.inference.InferenceLauncher --solverArgs="backEndType=maxsatbackend.Lingeling,solveInParallel=false" --checker dataflow.DataflowChecker --solver dataflow.solvers.backend.DataflowConstraintSolver --mode INFER --hacks=true $*
+
+export CLASSPATH=$ROOT/generic-type-inference-solver/bin:.
+
+$ROOT/checker-framework-inference/scripts/inference-dev checkers.inference.InferenceLauncher --solverArgs="backEndType=maxsatbackend.Lingeling,solveInParallel=false" --checker dataflow.DataflowChecker --solver dataflow.solvers.backend.DataflowConstraintSolver --mode INFER --hacks=true $*

--- a/scripts/dataflow/inference-logiQL.sh
+++ b/scripts/dataflow/inference-logiQL.sh
@@ -5,5 +5,8 @@ export MYDIR=`dirname $0`/..
 export ROOT=$MYDIR/../..
 export LOGICDATA=./logiqldata
 distDir=$CHINF"/dist"
-java -classpath "$distDir"/checker.jar:"$distDir"/plume.jar:"$distDir"/checker-framework-inference.jar:$ROOT/generic-type-inference-solver/bin:. checkers.inference.InferenceLauncher --solverArgs="backEndType=logiqlbackend.LogiQL" --checker dataflow.DataflowChecker --solver dataflow.solvers.backend.DataflowConstraintSolver --mode INFER --hacks=true $*
+
+export CLASSPATH=$ROOT/generic-type-inference-solver/bin:.
+
+$ROOT/checker-framework-inference/scripts/inference-dev checkers.inference.InferenceLauncher --solverArgs="backEndType=logiqlbackend.LogiQL" --checker dataflow.DataflowChecker --solver dataflow.solvers.backend.DataflowConstraintSolver --mode INFER --hacks=true $*
 rm -r $LOGICDATA

--- a/scripts/dataflow/typecheck.sh
+++ b/scripts/dataflow/typecheck.sh
@@ -4,4 +4,7 @@ export MYDIR=`dirname $0`/..
 . $MYDIR/setup.sh
 export ROOT=$MYDIR/../..
 distDir=$CHINF"/dist"
-java -classpath "$distDir"/checker.jar:"$distDir"/plume.jar:"$distDir"/checker-framework-inference.jar:$ROOT/generic-type-inference-solver/bin:.  checkers.inference.InferenceLauncher --checker dataflow.DataflowChecker --mode TYPECHECK --hacks=true $*
+
+export CLASSPATH=$ROOT/generic-type-inference-solver/bin:.
+
+$ROOT/checker-framework-inference/scripts/inference-dev checkers.inference.InferenceLauncher --checker dataflow.DataflowChecker --mode TYPECHECK --hacks=true $*

--- a/scripts/ostrusted/inference-MAXSAT-nograph.sh
+++ b/scripts/ostrusted/inference-MAXSAT-nograph.sh
@@ -4,4 +4,7 @@ export MYDIR=`dirname $0`/..
 . $MYDIR/setup.sh
 export ROOT=$MYDIR/../..
 distDir=$CHINF"/dist"
-java -classpath "$distDir"/checker.jar:"$distDir"/plume.jar:"$distDir"/checker-framework-inference.jar:$ROOT/generic-type-inference-solver/bin checkers.inference.InferenceLauncher --solverArgs="backEndType=maxsatbackend.MaxSat,useGraph=false,solveInParallel=false" --checker ostrusted.OsTrustedChecker --solver constraintsolver.ConstraintSolver --mode INFER --hacks=true $*
+
+export CLASSPATH=$ROOT/generic-type-inference-solver/bin
+
+$ROOT/checker-framework-inference/scripts/inference-dev checkers.inference.InferenceLauncher --solverArgs="backEndType=maxsatbackend.MaxSat,useGraph=false,solveInParallel=false" --checker ostrusted.OsTrustedChecker --solver constraintsolver.ConstraintSolver --mode INFER --hacks=true $*

--- a/scripts/ostrusted/inference-MAXSAT-parallel-graph.sh
+++ b/scripts/ostrusted/inference-MAXSAT-parallel-graph.sh
@@ -4,4 +4,7 @@ export MYDIR=`dirname $0`/..
 . $MYDIR/setup.sh
 export ROOT=$MYDIR/../..
 distDir=$CHINF"/dist"
-java -classpath "$distDir"/checker.jar:"$distDir"/plume.jar:"$distDir"/checker-framework-inference.jar:$ROOT/generic-type-inference-solver/bin checkers.inference.InferenceLauncher --solverArgs="backEndType=maxsatbackend.MaxSat,collectStatistic=true" --checker ostrusted.OsTrustedChecker --solver constraintsolver.ConstraintSolver --mode INFER --hacks=true $*
+
+export CLASSPATH=$ROOT/generic-type-inference-solver/bin
+
+$ROOT/checker-framework-inference/scripts/inference-dev checkers.inference.InferenceLauncher --solverArgs="backEndType=maxsatbackend.MaxSat,collectStatistic=true" --checker ostrusted.OsTrustedChecker --solver constraintsolver.ConstraintSolver --mode INFER --hacks=true $*

--- a/scripts/ostrusted/inference-MAXSAT-sequence-graph.sh
+++ b/scripts/ostrusted/inference-MAXSAT-sequence-graph.sh
@@ -4,4 +4,7 @@ export MYDIR=`dirname $0`/..
 . $MYDIR/setup.sh
 export ROOT=$MYDIR/../..
 distDir=$CHINF"/dist"
-java -classpath "$distDir"/checker.jar:"$distDir"/plume.jar:"$distDir"/checker-framework-inference.jar:$ROOT/generic-type-inference-solver/bin checkers.inference.InferenceLauncher --solverArgs="backEndType=maxsatbackend.MaxSat,solveInParallel=false" --checker ostrusted.OsTrustedChecker --solver constraintsolver.ConstraintSolver --mode INFER --hacks=true $*
+
+export CLASSPATH=$ROOT/generic-type-inference-solver/bin
+
+$ROOT/checker-framework-inference/scripts/inference-dev checkers.inference.InferenceLauncher --solverArgs="backEndType=maxsatbackend.MaxSat,solveInParallel=false" --checker ostrusted.OsTrustedChecker --solver constraintsolver.ConstraintSolver --mode INFER --hacks=true $*

--- a/scripts/ostrusted/inference-debug.sh
+++ b/scripts/ostrusted/inference-debug.sh
@@ -4,4 +4,7 @@ export MYDIR=`dirname $0`/..
 . $MYDIR/setup.sh
 export ROOT=$MYDIR/../..
 distDir=$CHINF"/dist"
-java -classpath "$distDir"/checker.jar:"$distDir"/plume.jar:"$distDir"/checker-framework-inference.jar:$ROOT/generic-type-inference-solver/bin  checkers.inference.InferenceLauncher --checker ostrusted.OsTrustedChecker --solver checkers.inference.solver.DebugSolver --mode INFER --hacks=true $*
+
+export CLASSPATH=$ROOT/generic-type-inference-solver/bin
+
+$ROOT/checker-framework-inference/scripts/inference-dev checkers.inference.InferenceLauncher --checker ostrusted.OsTrustedChecker --solver checkers.inference.solver.DebugSolver --mode INFER --hacks=true $*

--- a/scripts/ostrusted/inference-logiQL-graph.sh
+++ b/scripts/ostrusted/inference-logiQL-graph.sh
@@ -5,5 +5,8 @@ export MYDIR=`dirname $0`/..
 export ROOT=$MYDIR/../..
 export LOGICDATA=./logiqldata
 distDir=$CHINF"/dist"
-java -classpath "$distDir"/checker.jar:"$distDir"/plume.jar:"$distDir"/checker-framework-inference.jar:$ROOT/generic-type-inference-solver/bin checkers.inference.InferenceLauncher --solverArgs="backEndType=logiqlbackend.LogiQL" --checker ostrusted.OsTrustedChecker --solver constraintsolver.ConstraintSolver --mode INFER --hacks=true $*
+
+export CLASSPATH=$ROOT/generic-type-inference-solver/bin
+
+$ROOT/checker-framework-inference/scripts/inference-dev checkers.inference.InferenceLauncher --solverArgs="backEndType=logiqlbackend.LogiQL" --checker ostrusted.OsTrustedChecker --solver constraintsolver.ConstraintSolver --mode INFER --hacks=true $*
 rm -r $LOGICDATA

--- a/scripts/ostrusted/inference-logiQL-nograph.sh
+++ b/scripts/ostrusted/inference-logiQL-nograph.sh
@@ -5,5 +5,8 @@ export MYDIR=`dirname $0`/..
 export ROOT=$MYDIR/../..
 export LOGICDATA=./logiqldata
 distDir=$CHINF"/dist"
-java -classpath "$distDir"/checker.jar:"$distDir"/plume.jar:"$distDir"/checker-framework-inference.jar:$ROOT/generic-type-inference-solver/bin checkers.inference.InferenceLauncher --solverArgs="backEndType=logiqlbackend.LogiQL,useGraph=false" --checker ostrusted.OsTrustedChecker --solver constraintsolver.ConstraintSolver --mode INFER --hacks=true $*
+
+export CLASSPATH=$ROOT/generic-type-inference-solver/bin
+
+$ROOT/checker-framework-inference/scripts/inference-dev checkers.inference.InferenceLauncher --solverArgs="backEndType=logiqlbackend.LogiQL,useGraph=false" --checker ostrusted.OsTrustedChecker --solver constraintsolver.ConstraintSolver --mode INFER --hacks=true $*
 rm -r $LOGICDATA


### PR DESCRIPTION
update scripts in GTIS.

- using `checker-framework-inference/scripts/inference-dev` in `dataflow` and `osTrusted` scripts. This would use the eclipse output version of CF and CFI, which is more friendly for debug purpose. i.e. doesn't need to re-compile every thing when debugging.

- using gradle system of GTIS in `integrationSetup.sh`.

