### PR TITLE
using finally block to avoid losing statistic when exception happens

### DIFF
--- a/src/util/PrintUtils.java
+++ b/src/util/PrintUtils.java
@@ -49,7 +49,7 @@ public class PrintUtils {
     }
 
     public static void writeStatistic(Map<StatisticKey, Long> statistic) {
-        String writePath = new File(new File("").getAbsolutePath()).toString() + "/statistic.txt";
+        String writePath = new File(new File("").getAbsolutePath()).toString() + File.separator + "solver-statistic.txt";
         StringBuilder sb = new StringBuilder();
         for (StatisticKey j : statistic.keySet()) {
             if (statistic.get(j) != (long) 0) {


### PR DESCRIPTION
Small modification: using try-finally blocks wrap the solving process in `ConstraintSolver#solve()`, and print statistic in finally block.

This would ensure we have the statistic informations even if some exceptions has been thrown during the solving process.

minor other modification:

- change solver statistic file name to a better one.