### PR TITLE
Exit with a non-zero exit code if solver fails.

### DIFF
--- a/src/maxsatbackend/MaxSatBackEnd.java
+++ b/src/maxsatbackend/MaxSatBackEnd.java
@@ -215,12 +215,13 @@ public class MaxSatBackEnd extends BackEnd<VecInt[], VecInt[]> {
             }
 
             if (isSatisfiable) {
-            // saving memory of JVM...
-            this.softClauses.clear();
+                // saving memory of JVM...
+                this.softClauses.clear();
                 result = decode(solver.model());
                 // PrintUtils.printResult(result);
             } else {
                 System.out.println("Not solvable!");
+                System.exit(1);
             }
 
         } catch (Throwable e) {


### PR DESCRIPTION
When run with via Inference[Dev]Solver, currently even with failure the inference script will say that inference succeeded since it only checks for a non-zero exit code.

Only problem is possibly with parallel solvers. Is it fine to exit if any of them isn't solvable? @CharlesZ-Chen 