### PR TITLE
Add a new 'explain' flag to provide more detailed information about why inference failed to find a solution.

### DIFF
--- a/src/maxsatbackend/MaxSatBackEnd.java
+++ b/src/maxsatbackend/MaxSatBackEnd.java
@@ -211,10 +211,9 @@ public class MaxSatBackEnd extends BackEnd<VecInt[], VecInt[]> {
             boolean isSatisfiable = solver.isSatisfiable();
             this.solvingEnd = System.currentTimeMillis();
 
-            boolean graph = (configuration.get("useGraph") == null || configuration.get("useGraph")
-                    .equals("true")) ? true : false;
-            boolean parallel = (configuration.get("solveInParallel") == null || configuration.get(
-                    "solveInParallel").equals("true")) ? true : false;
+            boolean graph = configuration.get("useGraph") == null || configuration.get("useGraph").equals("true");
+            boolean parallel = configuration.get("solveInParallel") == null ||
+                    configuration.get("solveInParallel").equals("true");
             long solvingTime = solvingEnd - solvingStart;
             if (graph) {
                 if (parallel) {


### PR DESCRIPTION
Example program that will fail to infer:
```java
import GUT.qual.Peer;
import GUT.qual.Rep;

public class Unsolvable {
    Object foo;

    public void init() {
        this.foo = new @Rep Object();

        do_something(this.foo);
    }   

    void do_something(@Peer Object a) {}
}
```

With the new flag, the output is:
```
% $CFI/scripts/inference-dev --checker=GUTI.GUTIChecker --solver=GUTI.GUTIConstraintSolver --mode ROUNDTRIP -afud annotated --solverArgs="explain=true" Unsolvable.java --logLevel=OFF

--- Inferring ---

configuration: 
back end type: maxsatbackend.MaxSat; 
useGraph: true; 
solveInParallel: true.
Using ConstraintGraph!
c And the winner is solver1
Not solvable!
Inference failed because of the following inconsistent constraints:
	SubtypeConstraint: [RefinementVariableSlot(15), CombVariableSlot(14)] @ AstPathLocation( Unsolvable.init()V.null:Unsolvable:init()V::Method.body, Block.statement 0, ExpressionStatement.expression )
	EqualityConstraint: [RefinementVariableSlot(15), @GUT.qual.Rep] @ MissingLocation
	SubtypeConstraint: [CombVariableSlot(14), @GUT.qual.Peer] @ AstPathLocation( Unsolvable.init()V.null:Unsolvable:init()V::Method.body, Block.statement 1, ExpressionStatement.expression )

--- Inference failed ---
```

Some future tasks involve perhaps folding away that EqualityConstraint and simply substituting `@Peer` into the first SubtypeConstraint. Also instead maybe outputting a file and line number.