### PR TITLE
Fixed missing annotation on array component type

### DIFF
--- a/src/dataflow/DataflowInferenceTreeAnnotator.java
+++ b/src/dataflow/DataflowInferenceTreeAnnotator.java
@@ -142,7 +142,6 @@ public class DataflowInferenceTreeAnnotator extends InferenceTreeAnnotator {
 
     private void replaceATM(AnnotatedTypeMirror atm, AnnotationMirror dataflowAM) {
         final ConstantSlot cs = slotManager.createConstantSlot(dataflowAM);
-        slotManager.createConstantSlot(dataflowAM);
         AnnotationBuilder ab = new AnnotationBuilder(realTypeFactory.getProcessingEnv(), VarAnnot.class);
         ab.setValue("value", cs.getId());
         AnnotationMirror varAnno = ab.build();

--- a/src/dataflow/DataflowInferenceTreeAnnotator.java
+++ b/src/dataflow/DataflowInferenceTreeAnnotator.java
@@ -9,6 +9,7 @@ import org.checkerframework.javacutil.TreeUtils;
 
 import javax.lang.model.element.AnnotationMirror;
 import javax.lang.model.element.ExecutableElement;
+import javax.lang.model.type.TypeKind;
 import javax.lang.model.type.TypeMirror;
 
 import checkers.inference.InferenceAnnotatedTypeFactory;
@@ -107,10 +108,10 @@ public class DataflowInferenceTreeAnnotator extends InferenceTreeAnnotator {
             AnnotationMirror anno = DataflowUtils.genereateDataflowAnnoFromByteCode(atm,
                     this.realTypeFactory.getProcessingEnv());
 
-            if (atm instanceof AnnotatedArrayType) {
+            if (atm.getKind() == TypeKind.ARRAY) {
                 // If the return type of a byte code method is Array type,
                 // also generated Dataflow Annotation on Array component type.
-                relaceArrayComponentATM((AnnotatedArrayType) atm);
+                replaceArrayComponentATM((AnnotatedArrayType) atm);
             }
 
             replaceATM(atm, anno);
@@ -121,21 +122,21 @@ public class DataflowInferenceTreeAnnotator extends InferenceTreeAnnotator {
     }
 
     /**
-     * Replace annotated type mirror by Dataflow Annotation for a given {@link AnnotatedArrayType}.<br>
-     * <br>
-     * For more than one dimension array, this method will recursively replace array's component atm by Dataflow Annoatation.
+     * Add the bytecode default Dataflow annotation for component type of the given {@link AnnotatedArrayType}.
      *
-     * @param arrayAtm the given {@link AnnotatedArrayType} whose component's atm will be replaced by this method.
+     *<p> For multi-dimensional array, this method will recursively add bytecode default Dataflow annotation to array's component type.
+     *
+     * @param arrayAtm the given {@link AnnotatedArrayType}, whose component type will be added the bytecode default.
      */
-    private void relaceArrayComponentATM(AnnotatedArrayType arrayAtm) {
+    private void replaceArrayComponentATM(AnnotatedArrayType arrayAtm) {
         AnnotatedTypeMirror componentAtm = arrayAtm.getComponentType();
         AnnotationMirror componentAnno = DataflowUtils.genereateDataflowAnnoFromByteCode(componentAtm,
                 this.realTypeFactory.getProcessingEnv());
         replaceATM(componentAtm, componentAnno);
 
-        if (componentAtm instanceof AnnotatedArrayType) {
+        if (componentAtm.getKind() == TypeKind.ARRAY) {
             //if component is also an array type, then recursively annotate its component also.
-            relaceArrayComponentATM((AnnotatedArrayType) componentAtm);
+            replaceArrayComponentATM((AnnotatedArrayType) componentAtm);
         }
     }
 

--- a/testing/dataflow/TestByteCodeMethodArrayComponentType.java
+++ b/testing/dataflow/TestByteCodeMethodArrayComponentType.java
@@ -1,0 +1,27 @@
+// PR: https://github.com/opprop/generic-type-inference-solver/pull/17
+
+import java.io.*;
+import java.util.*;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import dataflow.qual.DataFlow;
+
+class Dummy {
+    public void test(String path) {
+        //:: fixable-error: (assignment.type.incompatible)
+        @DataFlow(typeNameRoots={"java.lang.String"}) String str = Dummy.getPath(path);
+    }
+
+    public static String getPath(String pathPart){
+        String pathFull = "";
+        String [] arrOfPathPart = pathPart.split("");
+        pathFull = pathFull + arrOfPathPart[0];
+        return pathFull;
+    }
+
+    public static void checkFile(String filePath) throws Exception {
+        String pathFull = getPath(filePath);  
+        FileInputStream fstream = new FileInputStream(filePath);
+    }
+}

--- a/testing/dataflow/TestByteCodeMethodArrayComponentType.java
+++ b/testing/dataflow/TestByteCodeMethodArrayComponentType.java
@@ -7,7 +7,7 @@ import java.util.regex.Pattern;
 
 import dataflow.qual.DataFlow;
 
-class Dummy {
+class TestByteCodeMethodArrayComponentType {
     public void test(String path) {
         //:: fixable-error: (assignment.type.incompatible)
         @DataFlow(typeNameRoots={"java.lang.String"}) String str = Dummy.getPath(path);

--- a/testing/dataflow/TestByteCodeMethodArrayComponentType.java
+++ b/testing/dataflow/TestByteCodeMethodArrayComponentType.java
@@ -10,17 +10,17 @@ import dataflow.qual.DataFlow;
 class TestByteCodeMethodArrayComponentType {
     public void test(String path) {
         //:: fixable-error: (assignment.type.incompatible)
-        @DataFlow(typeNameRoots={"java.lang.String"}) String str = Dummy.getPath(path);
+        @DataFlow(typeNameRoots={"java.lang.String"}) String str = getPath(path);
     }
 
-    public static String getPath(String pathPart){
+    public String getPath(String pathPart){
         String pathFull = "";
         String [] arrOfPathPart = pathPart.split("");
         pathFull = pathFull + arrOfPathPart[0];
         return pathFull;
     }
 
-    public static void checkFile(String filePath) throws Exception {
+    public void checkFile(String filePath) throws Exception {
         String pathFull = getPath(filePath);  
         FileInputStream fstream = new FileInputStream(filePath);
     }


### PR DESCRIPTION
Issue:

When a byte code method type is array type, only annotate the main type with Dataflow Annotation is not enough, we should also annotated the array component type.

E.g.

```java
@Var1 String  @Var2 [] strArr = bytecodeM.getStrArr();
```
For the return type of `bytecodeM`, if we only annotate its main type, then the annotated result would be `@DataFlowTop String @Dataflow(typeroots="java.lang.String []") []`, as the default annotation is `DataflowTop` on missing annotated place. This will cause unreasonable constraints being generated, E.g.:

```
@Var1 :> @DataFlowTop
```

To solve this issue, we should also annotate Array Component type when a byte code method type is array type, i.e. for above example, the annotated result for return type of ` bytecodeM` should be `@Dataflow(typeroots="java.lang.String") String @Dataflow(typeroots="java.lang.String []") []`.

Test case:

```java
//Test.java
import java.io.*;
import java.util.*;
import java.util.regex.Matcher;
import java.util.regex.Pattern;

class Dummy {
    public static String getPath(String pathPart){
        String pathFull = "";
        String [] arrOfPathPart = pathPart.split("");
        pathFull = pathFull + arrOfPathPart[0];
        return pathFull;
    }

    public static void checkFile(String filePath) throws Exception {
        String pathFull = getPath(filePath);  
        FileInputStream fstream = new FileInputStream(filePath);
    }
}
```

Expected output by running `script/dataflow/inference-MAXSAT-parallel.sh Test.java`:
```java
//Test.java
import dataflow.qual.DataFlow;
import java.io.*;
import java.util.*;
import java.util.regex.Matcher;
import java.util.regex.Pattern;

class Dummy {
    public static @DataFlow(typeNameRoots={"java.lang.String"}) String getPath(String pathPart){
        @DataFlow(typeNameRoots={"java.lang.String"})
        String pathFull = "";
        @DataFlow(typeNameRoots={"java.lang.String"})
        String @DataFlow(typeNameRoots={"java.lang.String[]"}) [] arrOfPathPart = pathPart.split("");
        pathFull = pathFull + arrOfPathPart[0];
        return pathFull;
    }

    public static void checkFile(String filePath) throws Exception {
        @DataFlow(typeNameRoots={"java.lang.String"})
        String pathFull = getPath(filePath);
        @DataFlow(typeNames={"java.io.FileInputStream"})
        FileInputStream fstream = new FileInputStream(filePath);
    }
}
```