### PR TITLE
Fix  strange BootstrapMethodError when running `gradle test` under Java 8  (on Mac OS X).

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -145,7 +145,7 @@ test {
         // A strange BootstrapMethodError would happened (on Mac OS X).
         // The only possible related discuss I found is:
         // https://groups.google.com/forum/#!topic/checker-framework-dev/eNJU6qiqhGQ
-       jvmArgs "-Xbootclasspath/p:$cfInferenceDir/dist/javac.jar"
+       jvmArgs "-Xbootclasspath/p:$checkerFrameworkDir/checker/dist/javac.jar"
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -138,7 +138,15 @@ test {
     testLogging {
         events "PASSED", "FAILED", "SKIPPED"
     }
-    jvmArgs "-Xbootclasspath/p:$cfInferenceDir/dist/javac.jar"
+    // Need to use Checker Framework version of javac when running under Java 7
+    // https://checkerframework.org/manual/#common-problems
+    if (JavaVersion.current() == JavaVersion.VERSION_1_7) {
+        // When adding CF version javac into bootclasspath under Java 8,
+        // A strange BootstrapMethodError would happened (on Mac OS X).
+        // The only possible related discuss I found is:
+        // https://groups.google.com/forum/#!topic/checker-framework-dev/eNJU6qiqhGQ
+       jvmArgs "-Xbootclasspath/p:$cfInferenceDir/dist/javac.jar"
+    }
 }
 
 libsDirName = "$gtisDir/dist"


### PR DESCRIPTION
When running `gradle test` under Java 8 on my machine (Mac OS X), I will get below error:

```
java.lang.BootstrapMethodError: call site initialization exception
        at java.lang.invoke.CallSite.makeSite(CallSite.java:341)
        at java.lang.invoke.MethodHandleNatives.linkCallSiteImpl(MethodHandleNatives.java:307)
        at java.lang.invoke.MethodHandleNatives.linkCallSite(MethodHandleNatives.java:297)
        at java.io.ObjectInputStream.<clinit>(ObjectInputStream.java:3578)
        at org.gradle.process.internal.worker.child.SystemApplicationClassLoaderWorker.call(SystemApplicationClassLoaderWorker.java:80)
        at org.gradle.process.internal.worker.child.SystemApplicationClassLoaderWorker.call(SystemApplicationClassLoaderWorker.java:45)
        at worker.org.gradle.process.internal.worker.GradleWorkerMain.run(GradleWorkerMain.java:62)
        at worker.org.gradle.process.internal.worker.GradleWorkerMain.main(GradleWorkerMain.java:67)
Caused by: java.lang.ClassCastException: bootstrap method failed to produce a CallSite
        at java.lang.invoke.CallSite.makeSite(CallSite.java:332)
        ... 7 more
:test FAILED
``` 

The only possible reason for this is I add checker-framework version of `javac` (we need to use cf-version of javac under java 7 to running test, to avoid the `NoSuchFieldError` according to the cf manual.) into the `bootstrapclasspath` when running tests.

I have no idea of why this strange error happens, so as a workaround, I add a check statement in gradle test, to only add the cf-version of `javac` when running test under Java 7.