### PR TITLE
Fix bug in building constraint graph -- finding correct next vertex in BFS search

### DIFF
--- a/src/constraintgraph/GraphBuilder.java
+++ b/src/constraintgraph/GraphBuilder.java
@@ -134,7 +134,8 @@ public class GraphBuilder {
                 }
                 constantPathConstraints.add(edge.getConstraint());
 
-                Vertex next =  current.equals(edge.to) ? edge.getFromVertex() : edge.getToVertex();
+                Vertex next =  current.equals(edge.to) ? 
+                        edge.getFromVertex() : edge.getToVertex();
 
                 Set<Vertex> cacheSet;
                 if (this.vertexCache.keySet().contains(vertex)) {

--- a/src/constraintgraph/GraphBuilder.java
+++ b/src/constraintgraph/GraphBuilder.java
@@ -133,7 +133,9 @@ public class GraphBuilder {
                     }
                 }
                 constantPathConstraints.add(edge.getConstraint());
-                Vertex next = edge.getToVertex();
+
+                Vertex next =  current.equals(edge.to) ? edge.getFromVertex() : edge.getToVertex();
+
                 Set<Vertex> cacheSet;
                 if (this.vertexCache.keySet().contains(vertex)) {
                     cacheSet = vertexCache.get(vertex);


### PR DESCRIPTION
In graphBuilder there is a BFS search algorithm for building reachable path for constant vertex.

The bug is, when finding the next vertex to be traversed, it is not always be the "to" vertex in the edge (In Jason's implementation, an edge is consist of a "from" vertex and a "to" vertex).

We should check what the current vertex is, to decide what is the next vertex. i.e. if current vertex is the "from" vertex in the edge, then next vertex is "to" vertex. Otherwise, the next vertex should be "from" vertex.